### PR TITLE
Only use real-time translation for text no longer than 280 characters

### DIFF
--- a/patches/tongwen-core+3.2.3.patch
+++ b/patches/tongwen-core+3.2.3.patch
@@ -1,3 +1,38 @@
+diff --git a/node_modules/tongwen-core/.DS_Store b/node_modules/tongwen-core/.DS_Store
+new file mode 100644
+index 0000000..726a431
+Binary files /dev/null and b/node_modules/tongwen-core/.DS_Store differ
+diff --git a/node_modules/tongwen-core/cjs/.DS_Store b/node_modules/tongwen-core/cjs/.DS_Store
+new file mode 100644
+index 0000000..4ce4121
+Binary files /dev/null and b/node_modules/tongwen-core/cjs/.DS_Store differ
+diff --git a/node_modules/tongwen-core/cjs/dictionary/.DS_Store b/node_modules/tongwen-core/cjs/dictionary/.DS_Store
+new file mode 100644
+index 0000000..ae7b239
+Binary files /dev/null and b/node_modules/tongwen-core/cjs/dictionary/.DS_Store differ
+diff --git a/node_modules/tongwen-core/cjs/dictionary/shared/group-pack.js b/node_modules/tongwen-core/cjs/dictionary/shared/group-pack.js
+index d09db7d..f195632 100644
+--- a/node_modules/tongwen-core/cjs/dictionary/shared/group-pack.js
++++ b/node_modules/tongwen-core/cjs/dictionary/shared/group-pack.js
+@@ -1,13 +1,6 @@
+ "use strict";
+-var __spreadArrays = (this && this.__spreadArrays) || function () {
+-    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+-    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+-        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+-            r[k] = a[j];
+-    return r;
+-};
+ Object.defineProperty(exports, "__esModule", { value: true });
+-var mergeList = function (list) { return Object.assign.apply(Object, __spreadArrays([{}], list)); };
++var mergeList = function (list) { return Object.assign.apply(Object, [{}].concat(list)); };
+ var group = function (words) {
+     return Object.entries(words).reduce(function (grouped, _a) {
+         var key = _a[0], value = _a[1];
+diff --git a/node_modules/tongwen-core/esm/.DS_Store b/node_modules/tongwen-core/esm/.DS_Store
+new file mode 100644
+index 0000000..7bfbb4f
+Binary files /dev/null and b/node_modules/tongwen-core/esm/.DS_Store differ
 diff --git a/node_modules/tongwen-core/esm/dictionary/shared/group-pack.js b/node_modules/tongwen-core/esm/dictionary/shared/group-pack.js
 index f710c63..6d616b3 100644
 --- a/node_modules/tongwen-core/esm/dictionary/shared/group-pack.js

--- a/public/libs/locales/de.json
+++ b/public/libs/locales/de.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "An Taskleiste anhängen",
 	"translateWhenPressingEnter": "Mit Enter übersetzen",
 	"realtime": "Echtzeit Übersetzung",
+	"realtimeDesc": "Diese Funktion funktioniert nur bei text, der nicht länger als 280 Zeichen.",
 	"rateMacAppStore": "Translatium im Mac App Store bewerten",
 	"rateMicrosoftStore": "Translatium im Microsoft Store bewerten",
 	"displayLanguage": "Zeige Sprachen",

--- a/public/libs/locales/en.json
+++ b/public/libs/locales/en.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "Attach to taskbar",
 	"translateWhenPressingEnter": "Translate when pressing Enter",
 	"realtime": "Real-time translation",
+	"realtimeDesc": "This feature only works with text no longer than 280 characters.",
 	"rateMacAppStore": "Rate Translatium on Mac App Store",
 	"rateMicrosoftStore": "Rate Translatium on Microsoft Store",
 	"displayLanguage": "Display language",

--- a/public/libs/locales/es.json
+++ b/public/libs/locales/es.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "Unir a la barra de tares",
 	"translateWhenPressingEnter": "Traducir cuando presionas Enter",
 	"realtime": "Traducción en tiempo real",
+	"realtimeDesc": "Esta característica sólo funciona con texto de no más de 280 caracteres.",
 	"rateMacAppStore": "Valorar Translatium en Mac App Store",
 	"rateMicrosoftStore": "Valorar Translatium en Microsoft Store",
 	"displayLanguage": "Mostrar idioma",

--- a/public/libs/locales/it.json
+++ b/public/libs/locales/it.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "Allega alla barra delle applicazioni",
 	"translateWhenPressingEnter": "Traduci quando premi Invio",
 	"realtime": "Traduzione in tempo reale",
+	"realtimeDesc": "Questa caratteristica funziona solo con il testo di non più di 280 caratteri.",
 	"rateMacAppStore": "Valuta Translatium sul Mac App Store",
 	"rateMicrosoftStore": "Valuta Translatium su Microsoft Store",
 	"displayLanguage": "Visualizza la lingua",

--- a/public/libs/locales/pl.json
+++ b/public/libs/locales/pl.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "Dołącz do paska zadań",
 	"translateWhenPressingEnter": "Tłumacz po naciśnięciu klawisza Enter",
 	"realtime": "Tłumaczenie w czasie rzeczywistym",
+	"realtimeDesc": "Ta funkcja działa tylko z tekstem nie więcej niż 280 znaków.",
 	"rateMacAppStore": "Oceń Translatium w Mac App Store",
 	"rateMicrosoftStore": "Oceń Translatium w Sklepie Microsoft",
 	"displayLanguage": "Język aplikacji",

--- a/public/libs/locales/pt.json
+++ b/public/libs/locales/pt.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "Anexar à barra de tarefas",
 	"translateWhenPressingEnter": "Traduzir ao pressionar Enter",
 	"realtime": "Tradução em Tempo Real",
+	"realtimeDesc": "Este recurso só funciona com o texto não é mais do que 280 caracteres.",
 	"rateMacAppStore": "Classifique o app Translatium na Mac App Store",
 	"rateMicrosoftStore": "Classifique o app Translatium na Microsoft Store",
 	"displayLanguage": "Idioma",

--- a/public/libs/locales/vi.json
+++ b/public/libs/locales/vi.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "Gắn vào taskbar",
 	"translateWhenPressingEnter": "Dịch khi nhấn Enter",
 	"realtime": "Dịch thời gian thực",
+	"realtimeDesc": "Tính năng này chỉ hoạt động với văn bản dài không quá 280 ký tự.",
 	"rateMacAppStore": "Đánh giá Translatium trên Mac App Store",
 	"rateMicrosoftStore": "Đánh giá Translatium trên Microsoft Store",
 	"displayLanguage": "Ngôn ngữ hiển thị",

--- a/public/libs/locales/zh-CN.json
+++ b/public/libs/locales/zh-CN.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "附加到任务栏",
 	"translateWhenPressingEnter": "按下「Enter」翻译",
 	"realtime": "实时翻译",
+	"realtimeDesc": "此功能只适用文本的时间不超过280符。",
 	"rateMacAppStore": "在 Mac App Store 上评价 Translatium",
 	"rateMicrosoftStore": "在 Microsoft Store 上评价 Translatium",
 	"displayLanguage": "显示语言",

--- a/public/libs/locales/zh-TW.json
+++ b/public/libs/locales/zh-TW.json
@@ -94,6 +94,7 @@
 	"attachToTaskbar": "附加到任務欄",
 	"translateWhenPressingEnter": "按下「Enter」翻譯",
 	"realtime": "實時翻譯",
+	"realtimeDesc": "此功能只適用文本的時間不超過280符。",
 	"rateMacAppStore": "在 Mac App Store 上評價 Translatium",
 	"rateMicrosoftStore": "在 Microsoft Store 上評價 Translatium",
 	"displayLanguage": "顯示語言",

--- a/src/components/pages/preferences/index.js
+++ b/src/components/pages/preferences/index.js
@@ -207,7 +207,10 @@ const Preferences = (props) => {
         <Paper elevation={0} className={classes.paper}>
           <List dense disablePadding>
             <ListItem>
-              <ListItemText primary={getLocale('realtime')} />
+              <ListItemText
+                primary={getLocale('realtime')}
+                secondary={getLocale('realtimeDesc')}
+              />
               <ListItemSecondaryAction>
                 <Switch
                   edge="end"

--- a/src/state/pages/home/actions.js
+++ b/src/state/pages/home/actions.js
@@ -94,7 +94,13 @@ export const updateInputText = (
   if (currentInputText === inputText) return;
 
   clearTimeout(timeout);
-  if (realtime === true && fullscreenInputBox === false && inputText.trim().length > 0) {
+  // only run real time translation if the text no longer than 280 characters (Twitter's limit)
+  if (
+    realtime === true
+    && fullscreenInputBox === false
+    && inputText.trim().length > 0
+    && inputText.length <= 280
+  ) {
     dispatch({
       type: UPDATE_OUTPUT,
       output: null,


### PR DESCRIPTION
Reason: API quota.